### PR TITLE
Correct boundary conditions

### DIFF
--- a/cases/vans/case2/model-A.prm
+++ b/cases/vans/case2/model-A.prm
@@ -65,48 +65,15 @@ end
 #---------------------------------------------------
 
 subsection boundary conditions
-  set number = 4
+  set number = 1
   subsection bc 0
     set id   = 0
     set type = function
     subsection u
-      set Function expression = exp(sin(-pi)*sin(pi*y))/exp(1)
+      set Function expression = 1/exp(1)
     end
     subsection v
-      set Function expression = exp(sin(-pi)*sin(pi*y))/exp(1)
-    end
-  end
-
-  subsection bc 1
-    set id   = 1
-    set type = function
-    subsection u
-      set Function expression = exp(sin(pi)*sin(pi*y))/exp(1)
-    end
-    subsection v
-      set Function expression = exp(sin(pi)*sin(pi*y))/exp(1)
-    end
-  end
-
-  subsection bc 2
-    set id   = 2
-    set type = function
-    subsection u
-      set Function expression = exp(sin(pi*x)*sin(-pi))/exp(1)
-    end
-    subsection v
-      set Function expression = exp(sin(pi*x)*sin(-pi))/exp(1)
-    end
-  end
-
-  subsection bc 3
-    set id   = 3
-    set type = function
-    subsection u
-      set Function expression = exp(sin(pi*x)*sin(pi))/exp(1)
-    end
-    subsection v
-      set Function expression = exp(sin(pi*x)*sin(pi))/exp(1)
+      set Function expression = 1/exp(1)
     end
   end
 end


### PR DESCRIPTION
In the ``cases/vans/case2/model-A.prm``, the boundary condition was specified for 4 boundary ids, whereas the ``colorize`` variable was set to ``false``. This mean that only the condition at the boundary with ``id=0`` was actually taken into account. This is corrected here.